### PR TITLE
Update freeMem() function / fixed freemem word

### DIFF
--- a/YAFFA.ino
+++ b/YAFFA.ino
@@ -632,7 +632,7 @@ SKIP:                // common code to skip initial character
 /** freeMem returns the amount of free forth space left.                     **/
 /******************************************************************************/
 static unsigned int freeMem(void) {
-  return (pHere - forthSpace);
+  return (((int)&forthSpace[FORTH_SIZE] - (int)pHere) / sizeof(cell_t));
 }
 
 /******************************************************************************/


### PR DESCRIPTION
Currently `freemem` does not return the amount of bytes used by forth space, as stated by the freeMem() function comment, but the amount of bytes used:

```
 Forth Space: Size 682 Cells, Starts at $175, Ends at $6C8
 C Heap:  183 ($B7) bytes free
 EEPROM Size:1024

 Load from EEPROM.
 Inhibited by pin 14.
>> freemem .
0  OK
>> : EMIT-Q 81 EMIT ;
 OK
>> freemem .
10  OK
```

The patch corrects freeMem() function behaviour:

```
 Forth Space: Size 682 Cells, Starts at $175, Ends at $6C8
 C Heap:  183 ($B7) bytes free
 EEPROM Size:1024

 Load from EEPROM.
 Inhibited by pin 14.
>> freemem .
682  OK
>> : EMIT-Q 81 EMIT ;
 OK
>> freemem .
671  OK
```

Now the number returned by `freemem` matches the information displayed on startup. It also shows that adding a new word decreases available forth space, not increases it.
