### PR TITLE
Reverse order of operands in example code 

### DIFF
--- a/test.fth
+++ b/test.fth
@@ -1,9 +1,9 @@
 : test
-    1 13 pinMode
+    13 1 pinMode
     begin
-        0 13 pinWrite
+        13 0 pinWrite
         500 delay
-        1 13 pinWrite
+        13 1 pinWrite
         500 delay
     0 until 
 ;


### PR DESCRIPTION
I was trying out the example Forth code in test.fth, and realized that the parameters to pinWrite and pinMode needed to be swapped for it to work (see definitions of pinMode and pinWrite in Dictionary.ino). Just thought I would try to push the fix upstream.

Thanks
Michele